### PR TITLE
Printer name bug, fix #2

### DIFF
--- a/octodash/start.sh
+++ b/octodash/start.sh
@@ -22,7 +22,7 @@ jq ".config.octoprint.accessToken |= \"$OCTOPRINT_APIKEY\"" < $FILE > $TMP && mv
 # However, it sets a default of Octobalena if one is not provided.
 
 if [[ -z "$PRINTER_NAME" ]]; then
-  jq ".config.printer.name |= Octobalena" < $FILE > $TMP && mv $TMP $FILE
+  jq ".config.printer.name |= \"Octobalena\"" < $FILE > $TMP && mv $TMP $FILE
 else
   jq ".config.printer.name |= \"$PRINTER_NAME\"" < $FILE > $TMP && mv $TMP $FILE
 fi

--- a/octodash/start.sh
+++ b/octodash/start.sh
@@ -21,7 +21,7 @@ jq ".config.octoprint.accessToken |= \"$OCTOPRINT_APIKEY\"" < $FILE > $TMP && mv
 # This takes the PRINTER_NAME specified on the balena dashboard and does the same processing that we do with the OCTOPRINT_APIKEY.
 # However, it sets a default of Octobalena if one is not provided.
 
-if [[ -n "$PRINTER_NAME" ]]; then
+if [[ -z "$PRINTER_NAME" ]]; then
   jq ".config.printer.name |= Octobalena" < $FILE > $TMP && mv $TMP $FILE
 else
   jq ".config.printer.name |= \"$PRINTER_NAME\"" < $FILE > $TMP && mv $TMP $FILE


### PR DESCRIPTION
This fixes #2 

Explanation from the issue:

> The issue was two fold. I had mistakenly used `-z` in the bash logic rather than `-n` which is the opposite logic that I intended. I always get this wrong as I remember "-n" as meaning "not" which is *not* the case!
> 
> From `man bash` section `CONDITIONAL EXPRESSIONS`
> Run this command if you wish to see it
> `man --pager='less -p ^CONDITIONAL\ EXPRESSIONS' bash`
> ```
>        -z string
>               True if the length of string is zero.
>        string
>        -n string
>               True if the length of string is non-zero.
> ```