### PR TITLE
Add mDNS CNAME publishing and reverse proxy via Host: headers through Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Remotely control your 3d-printer with [octoprint](https://github.com/foosel/Octo
 
 **octoprint can be exposed on port 80 which can be remotely accessible via balena.io [public URL](https://docs.balena.io/management/devices/#enable-public-device-url) feature**
 
+By default, the device can be reached at `octobalena.local` if mDNS is working on your device.
+
 # Configure via [environment variables](https://docs.resin.io/management/env-vars/)
 
 ## Octoprint Service Variables

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Variable Name | Value | Description | Default
 **`OCTOPRINT_APIKEY`** | `STRING` | Needed for OctoDash to interact with Octoprint | 
 **`PRINTER_NAME`** | `STRING` | Name of the printer, as shows up in the bottom left of OctoDash  | Octobalena
 
+## mdns-publisher Service Variables
+Variable Name | Value | Description | Default
+------------ | ------------- | ------------- | -------------
+**`OCTOPRINT_HOSTNAME`** | `STRING` | Adds CNAME for mDNS so device is reachable at string.local | octobalena
+
 ## Getting started
 
 - Sign up on [balena.io](https://dashboard.balena.io/signup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 volumes:
-    octoprint-data:
+  octoprint-data: {}
+  traefik: {}
 services:
   octoprint:
     build: ./octoprint
@@ -9,13 +10,26 @@ services:
       - 'octoprint-data:/data'
     privileged: true
     ports:
-      - "80:80"
-#  octodetect:
-#    build: ./octodetect
-#    restart: always
-#    privileged: true
-#    depends_on:
-#      - octoprint
+      - '5000:5000'
+    labels:
+      io.balena.features.supervisor-api: '1'
+      traefik.enable: 'true'
+      traefik.http.services.octoprint.loadbalancer.server.port: '5000'  
+
+      traefik.http.routers.octoprint-balena.rule: 'HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.balena-devices.com`)'
+      traefik.http.routers.octoprint-balena.entrypoints: 'web'
+      traefik.http.routers.octoprint-balena.tls: 'false'   
+
+      traefik.http.routers.octoprint.rule: 'HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.local`) || HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.localdomain`) || HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.lan`)'
+      traefik.http.routers.octoprint.entrypoints: 'websecure'
+      traefik.http.routers.octoprint.tls: 'true'
+
+      traefik.http.routers.octoprint-insecure.rule: 'HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.local`) || HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.localdomain`) || HostRegexp(`{subdomain:[a-zA-Z0-9\-]+}.lan`)'
+      traefik.http.routers.octoprint-insecure.entrypoints: 'web'
+      traefik.http.routers.octoprint-insecure.middlewares: 'redirect-to-https'
+
+      traefik.http.middlewares.redirect-to-https.redirectscheme.scheme: 'https'
+      traefik.http.middlewares.redirect-to-https.redirectscheme.permanent: 'true'
   octodash:
     restart: always
     build: ./octodash
@@ -24,4 +38,28 @@ services:
      - UDEV=1
     depends_on:
      - octoprint
-
+  traefik:
+    restart: always
+    build: ./traefik
+    ports:
+      - '80:80/tcp'
+      - '443:443/tcp'
+      - '8080:8080'
+    volumes:
+      - 'traefik:/etc/traefik'
+    environment:
+      TRAEFIK_LOG_LEVEL: 'INFO'
+      TRAEFIK_ENTRYPOINTS_WEBSECURE_ADDRESS: ':443'
+      TRAEFIK_ENTRYPOINTS_WEB_ADDRESS: ':80'
+      TRAEFIK_PROVIDERS_DOCKER: 'true'
+      TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: 'false'
+      TRAEFIK_PROVIDERS_DOCKER_ENDPOINT: 'unix:///var/run/balena.sock'
+      TRAEFIK_API_INSECURE: 'true'
+    labels:
+      io.balena.features.balena-socket: 'true'
+  mdns-publisher:
+    build: ./mdns-publisher
+    environment:
+      DBUS_SYSTEM_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
+    labels:
+      io.balena.features.dbus: '1'

--- a/mdns-publisher/Dockerfile.template
+++ b/mdns-publisher/Dockerfile.template
@@ -1,0 +1,18 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:edge
+
+RUN apk update && apk add --no-cache python3
+
+RUN apk update && apk add --no-cache --virtual .build-deps \
+    build-base \
+    python3-dev \
+    dbus-dev \
+    glib-dev \
+    py3-pip \
+    py3-wheel \
+    py3-setuptools && \
+    pip3 install --no-cache-dir mdns-publisher && \
+    apk del .build-deps
+
+COPY start.sh start.sh
+
+CMD ["sh","start.sh"]

--- a/mdns-publisher/start.sh
+++ b/mdns-publisher/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This takes the CONTAINER_HOSTNAME environment variable specified on the balena dashboard or other method and uses mdns-publish-cname to create a CNAME record on mDNS.
+# However, it sets a default of octobalena.local if nothing is provided.
+
+if [[ -z "$CONTAINER_HOSTNAME" ]]; then
+  mdns-publish-cname octobalena.local
+else
+  mdns-publish-cname ""$OCTOPRINT_HOSTNAME"".local
+fi

--- a/traefik/Dockerfile.template
+++ b/traefik/Dockerfile.template
@@ -1,0 +1,1 @@
+FROM --platform=linux/arm traefik:2.2.1


### PR DESCRIPTION
fixes #3, however opting not to reuse `PRINTER_NAME` as people might want to use these separately.