### PR TITLE
octoprint: Update API model with Octoprint API key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - '5000:5000'
     labels:
       io.balena.features.supervisor-api: '1'
+      io.balena.features.balena-api: '1'
       traefik.enable: 'true'
       traefik.http.services.octoprint.loadbalancer.server.port: '5000'  
 

--- a/octoprint/Dockerfile.raspberrypi3
+++ b/octoprint/Dockerfile.raspberrypi3
@@ -28,6 +28,8 @@ RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
     "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/master.zip" \
     "https://github.com/vitormhenrique/OctoPrint-Enclosure/archive/master.zip"
 
+# Adds support for obtaining OCTOPRINT_APIKEY and setting the octodash service variable automatically
+# https://github.com/MatthewCroughan/octobalena/pull/10
 RUN apk add --no-cache curl jq
 COPY update-balena-app.sh /update-balena-app.sh
 

--- a/octoprint/Dockerfile.raspberrypi3
+++ b/octoprint/Dockerfile.raspberrypi3
@@ -28,6 +28,9 @@ RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
     "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/master.zip" \
     "https://github.com/vitormhenrique/OctoPrint-Enclosure/archive/master.zip"
 
+RUN apk add --no-cache curl jq
+COPY update-balena-app.sh /update-balena-app.sh
+
 # Seed the initial config.yaml 
 COPY ./config.yaml /data/config.yaml
 

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -28,7 +28,6 @@ RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
     "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/master.zip" \
     "https://github.com/vitormhenrique/OctoPrint-Enclosure/archive/master.zip"
     
-
 RUN apk add --no-cache curl jq
 COPY update-balena-app.sh /update-balena-app.sh
 

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -29,6 +29,9 @@ RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
     "https://github.com/vitormhenrique/OctoPrint-Enclosure/archive/master.zip"
     
 
+RUN apk add --no-cache curl jq
+COPY update-balena-app.sh /update-balena-app.sh
+
 # Seed the initial config.yaml
 COPY ./config.yaml /data/config.yaml
 

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -27,7 +27,9 @@ RUN PYTHONUSERBASE=/usr/local/ pip install --no-cache-dir \
     "https://github.com/jneilliii/OctoPrint-UltimakerFormatPackage/archive/master.zip" \
     "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails/archive/master.zip" \
     "https://github.com/vitormhenrique/OctoPrint-Enclosure/archive/master.zip"
-    
+
+# Adds support for obtaining OCTOPRINT_APIKEY and setting the octodash service variable automatically  
+# https://github.com/MatthewCroughan/octobalena/pull/10    
 RUN apk add --no-cache curl jq
 COPY update-balena-app.sh /update-balena-app.sh
 

--- a/octoprint/supervisord.conf
+++ b/octoprint/supervisord.conf
@@ -31,3 +31,10 @@ stderr_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
+
+[program:update-balena]
+command=/update-balena-app.sh
+stderr_logfile_maxbytes=1024
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=1024
+stdout_logfile=/dev/stdout

--- a/octoprint/update-balena-app.sh
+++ b/octoprint/update-balena-app.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -e
+
+if [ -z $BALENA_API_KEY ]; then
+    echo "BALENA_API_KEY is not set. Exiting."
+    exit 1
+fi
+
+SLEEP_FOR=1
+while [ -z $OCTOPRINT_API_KEY ]
+do
+    echo "OctoPrint API Key not set. Sleeping ${SLEEP_FOR}s..."
+    sleep $SLEEP_FOR
+
+    SLEEP_FOR=5
+    OCTOPRINT_API_KEY="$(cat ~/.octoprint/config.yaml | grep key: | awk 'BEGIN {OFS = ":"} { print $2 }')"
+done
+
+
+OCTODASH_SI=$(curl -Ss \
+    --header "Authorization: Bearer ${BALENA_API_KEY}" \
+    --request GET \
+    'https://api.balena-cloud.com/v5/service_install?$top=1&$select=id&$filter=device/any(d:d/uuid%20eq%20%27'${BALENA_DEVICE_UUID}'%27)%20and%20installs__service/any(s:s/service_name%20eq%20%27octodash%27)' \
+    | jq .d[0].id)
+
+create_api_key() {
+    curl -f -Ss \
+        --header 'Accept: application/json' \
+        --header "Authorization: Bearer ${BALENA_API_KEY}" \
+        --header "Content-Type: application/json" \
+        --data-raw '{"service_install":'$OCTODASH_SI', "name":"OCTOPRINT_APIKEY", "value":"'$OCTOPRINT_API_KEY'"}' \
+        --request POST \
+        https://api.balena-cloud.com/v5/device_service_environment_variable
+}
+
+patch_api_key() {
+    curl -Ss \
+        --header 'Accept: application/json' \
+        --header "Authorization: Bearer ${BALENA_API_KEY}" \
+        --header "Content-Type: application/json" \
+        --data-raw '{"value":"'$OCTOPRINT_API_KEY'"}' \
+        --request PATCH \
+        'https://api.balena-cloud.com/v5/device_service_environment_variable?$top=1&$filter=service_install%20eq%20'$OCTODASH_SI'%20and%20name%20eq%20%27OCTOPRINT_APIKEY%27'
+}
+
+create_api_key || patch_api_key
+
+while [ true ]
+do
+    sleep 1
+done


### PR DESCRIPTION
When running Octoprint, the API key is pulled from the config
and a corresponding Device/Service API key is updated to match.

This triggers Octodash to restart and use the newly updated key.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>