### PR TITLE
Fix for various small issues

### DIFF
--- a/mdns-publisher/start.sh
+++ b/mdns-publisher/start.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# This takes the CONTAINER_HOSTNAME environment variable specified on the balena dashboard or other method and uses mdns-publish-cname to create a CNAME record on mDNS.
+# This takes the OCTOPRINT_HOSTNAME environment variable specified on the balena dashboard or other method and uses mdns-publish-cname to create a CNAME record on mDNS.
 # However, it sets a default of octobalena.local if nothing is provided.
 
-if [[ -z "$CONTAINER_HOSTNAME" ]]; then
+if [[ -z "$OCTOPRINT_HOSTNAME" ]]; then
   mdns-publish-cname octobalena.local
 else
   mdns-publish-cname ""$OCTOPRINT_HOSTNAME"".local

--- a/octoprint/Dockerfile.template
+++ b/octoprint/Dockerfile.template
@@ -6,18 +6,22 @@ RUN apt-get update && install_packages libavahi-compat-libdnssd1 \
                                        python3-dev \
                                        python3-wheel  \
                                        python3-pip \
+                                       python3-setuptools \
                                        fontconfig \
                                        libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libavfilter-dev libswscale-dev libswresample-dev \
                                        libsrtp2-dev libsrtp2-1 libopus-dev libvpx-dev \
                                        ffmpeg \
                                        pkg-config \
                                        python-dev python3-dev \
-                                       gcc g++ linux-headers wget dosfstools \
+                                       gcc g++ wget dosfstools \
                                        imagemagick libv4l-dev \
                                        git make cmake \
                                        haproxy dbus \
                                        libatlas-base-dev \
                                        avrdude \
+                                       libssl-dev libffi-dev \
+                                       libraspberrypi-bin \
+                                       curl jq
 
 # Update pip
 RUN pip3 install --upgrade pip
@@ -62,7 +66,6 @@ RUN pip3 install --no-cache-dir \
 
 # Adds support for obtaining OCTOPRINT_APIKEY and setting the octodash service variable automatically
 # https://github.com/MatthewCroughan/octobalena/pull/10
-RUN install_packages curl jq
 COPY update-balena-app.sh /usr/src/octobalena/update-balena-app.sh
 COPY start-mjpg-streamer.sh /usr/src/octobalena/start-mjpg-streamer.sh
 

--- a/octoprint/supervisord.conf
+++ b/octoprint/supervisord.conf
@@ -27,7 +27,7 @@ stdout_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 
 [program:octoprint]
-command=octoprint serve --iknowwhatimdoing --host 0.0.0.0 --basedir /data
+command=octoprint serve --iknowwhatimdoing --host 0.0.0.0 --basedir /data/octoprint
 stderr_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0

--- a/octoprint/update-balena-app.sh
+++ b/octoprint/update-balena-app.sh
@@ -8,13 +8,13 @@ if [ -z $BALENA_API_KEY ]; then
 fi
 
 SLEEP_FOR=1
-while [ -z $OCTOPRINT_API_KEY ]
+while [ -z $OCTOPRINT_APIKEY ]
 do
     echo "OctoPrint API Key not set. Sleeping ${SLEEP_FOR}s..."
     sleep $SLEEP_FOR
 
     SLEEP_FOR=5
-    OCTOPRINT_API_KEY="$(cat /data/config.yaml | grep key: | awk 'BEGIN {OFS = ":"} { print $2 }')"
+    OCTOPRINT_APIKEY="$(cat /data/config.yaml | grep key: | awk 'BEGIN {OFS = ":"} { print $2 }')"
 done
 
 
@@ -29,7 +29,7 @@ create_api_key() {
         --header 'Accept: application/json' \
         --header "Authorization: Bearer ${BALENA_API_KEY}" \
         --header "Content-Type: application/json" \
-        --data-raw '{"service_install":'$OCTODASH_SI', "name":"OCTOPRINT_APIKEY", "value":"'$OCTOPRINT_API_KEY'"}' \
+        --data-raw '{"service_install":'$OCTODASH_SI', "name":"OCTOPRINT_APIKEY", "value":"'$OCTOPRINT_APIKEY'"}' \
         --request POST \
         https://api.balena-cloud.com/v5/device_service_environment_variable
 }
@@ -39,7 +39,7 @@ patch_api_key() {
         --header 'Accept: application/json' \
         --header "Authorization: Bearer ${BALENA_API_KEY}" \
         --header "Content-Type: application/json" \
-        --data-raw '{"value":"'$OCTOPRINT_API_KEY'"}' \
+        --data-raw '{"value":"'$OCTOPRINT_APIKEY'"}' \
         --request PATCH \
         'https://api.balena-cloud.com/v5/device_service_environment_variable?$top=1&$filter=service_install%20eq%20'$OCTODASH_SI'%20and%20name%20eq%20%27OCTOPRINT_APIKEY%27'
 }


### PR DESCRIPTION
Scope: octoprint, mdns-publisher
Change-type: minor
Signed-off-by: Daniel James <daniel@thzinc.com>

# Fix for mdns-publisher

An unused `CONTAINER_HOSTNAME` was being used to determine whether to use the documented `OCTOPRINT_HOSTNAME` environment variable. This was preventing using a custom hostname as documented.

# Fix for Octoprint's usage of the `basedir`

Fixed issues caused when Octoprint attempts to restore a backup by renaming this path

Because the Docker volume is mounted to /data, it cannot be moved/renamed. Changing this basedir to a folder within /data allows Octoprint to move/rename its directory within the mounted volume.

# Fix for different spelling of `OCTOPRINT_APIKEY` environment variable

The `update-balena-app.sh` script was using `OCTOPRINT_API_KEY` instead of `OCTOPRINT_APIKEY`.

# Fix for build dependencies

While trying to build the `octoprint` container, there were a few missing packages. I added what was missing, removed what was not findable, and combined multiple calls to `install_packages`.